### PR TITLE
Tags fixes

### DIFF
--- a/cmd/loader/delete.go
+++ b/cmd/loader/delete.go
@@ -21,17 +21,15 @@ type DeleteOptions struct {
 func (o *DeleteOptions) Run() {
 	s, err := storage.NewStorage(viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Error on creating new storage: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
 	err = s.DeleteLoader(o.UUID)
 	if err != nil {
-		fmt.Fprintf(o.Err, "Error deleting loader %s: %v", o.UUID, err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
-
-	fmt.Fprintf(o.Out, "Successfully deleted loadeer %s", o.UUID)
 }
 
 func NewLoaderDeleteCmd(cliIO cliio.IO) *cobra.Command {

--- a/cmd/loader/find.go
+++ b/cmd/loader/find.go
@@ -116,7 +116,7 @@ func (o *FindOptions) Run() {
 	if o.UUID != "" {
 		loaderConf, err := o.db.GetLoaderByID(o.UUID)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while gettting loaders configuration: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
@@ -129,19 +129,19 @@ func (o *FindOptions) Run() {
 	} else if o.LoaderDescription != "" {
 		loaders, err = o.db.GetLoaderByDescription(o.LoaderDescription)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error getting loader configuration from the database: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	} else if o.RangeFind {
 		loaders, err = o.db.GetLoadersByRange(o.FromEpoch, o.ToEpoch, o.LoaderLimit)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error getting loader configuration from the database: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	} else {
 		loaders, err = o.db.GetLoaders(o.LoaderLimit)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error getting loader configuration from the database: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -161,7 +161,7 @@ func (o *FindOptions) Run() {
 	case "json":
 		output, err := json.MarshalIndent(loaderSummary, "", " ")
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while JSON marshaling output: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
@@ -169,7 +169,7 @@ func (o *FindOptions) Run() {
 	default:
 		b, err := o.render.RenderOutput(&loaderConfigurations)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while rendering output: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 		}
 		fmt.Fprintf(o.Out, "%s", string(b))
 	}

--- a/cmd/loader/run.go
+++ b/cmd/loader/run.go
@@ -220,7 +220,7 @@ func (o *RunOptions) CompleteDB() {
 
 	r, err := templates.NewRenderTemplate(viper.GetString("template"), viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't create render template: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
@@ -228,7 +228,7 @@ func (o *RunOptions) CompleteDB() {
 
 	o.Storage, err = storage.NewStorage(viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't create storage handler: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
@@ -237,7 +237,7 @@ func (o *RunOptions) CompleteDB() {
 	if o.UUID != "" {
 		o.Conf, err = o.Storage.GetLoaderByID(o.UUID)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error fetching loader configuration from the database: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -259,7 +259,7 @@ func (o *RunOptions) Complete() {
 		viper.SetConfigFile(viper.GetString("loader_config"))
 
 		if err := viper.MergeInConfig(); err != nil {
-			fmt.Fprintf(o.Err, "Error on loading benchmark configuration %s: %v\n", viper.GetString("loader_config"), err)
+			fmt.Fprintf(o.Err, "Error: %v\n", err)
 			os.Exit(1)
 		}
 	}
@@ -268,7 +268,7 @@ func (o *RunOptions) Complete() {
 	if viper.GetBool("save") {
 		o.Storage, err = storage.NewStorage(viper.GetString("db"))
 		if err != nil {
-			fmt.Fprintf(o.Err, "Can't create storage handler: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -285,7 +285,7 @@ func (o *RunOptions) Complete() {
 	for _, value := range viper.GetStringSlice("header") {
 		err := headers.Set(value)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error setting header %s: %v", value, err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -294,7 +294,7 @@ func (o *RunOptions) Complete() {
 		cookieHeader := fmt.Sprintf("Cookie: %s", viper.GetString("cookie"))
 		err = headers.Set(cookieHeader)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error setting cookie header: %v", err)
+			fmt.Fprintf(o.Err, "Error (setting cookie header): %v", err)
 			os.Exit(1)
 		}
 	}
@@ -302,7 +302,7 @@ func (o *RunOptions) Complete() {
 	for _, value := range viper.GetStringSlice("parameter") {
 		err := params.Set(value)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error setting parameter %s: %v", value, err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -311,7 +311,7 @@ func (o *RunOptions) Complete() {
 	if viper.GetString("ca") != "" {
 		caBody, err = os.ReadFile(viper.GetString("ca"))
 		if err != nil {
-			fmt.Fprintf(o.Err, "Could not read CA file: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -319,7 +319,7 @@ func (o *RunOptions) Complete() {
 	if viper.GetString("cert") != "" {
 		certBody, err = os.ReadFile(viper.GetString("cert"))
 		if err != nil {
-			fmt.Fprintf(o.Err, "Could not read Cert file: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -327,7 +327,7 @@ func (o *RunOptions) Complete() {
 	if viper.GetString("key") != "" {
 		keyBody, err = os.ReadFile("key")
 		if err != nil {
-			fmt.Fprintf(o.Err, "Could not read Key file: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -335,7 +335,7 @@ func (o *RunOptions) Complete() {
 	if viper.GetString("body") != "" {
 		body, err = os.ReadFile(viper.GetString("body"))
 		if err != nil {
-			fmt.Fprintf(o.Err, "Count not read body file: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}

--- a/cmd/loader/save.go
+++ b/cmd/loader/save.go
@@ -20,19 +20,19 @@ type SaveOptions struct {
 func (o *SaveOptions) Run() {
 	s, err := storage.NewStorage(viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Error opening database file: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
 	viper.SetConfigFile(viper.GetString("file"))
 	if err := viper.MergeInConfig(); err != nil {
-		fmt.Fprintf(o.Err, "Error on loading benchmark configuration: %v\n", err)
+		fmt.Fprintf(o.Err, "Error: %v\n", err)
 		os.Exit(1)
 	}
 
 	host := viper.GetString("url")
 	if host == "" {
-		fmt.Fprint(o.Err, "The url option has to provided")
+		fmt.Fprint(o.Err, "The Url option is mandatory")
 		os.Exit(1)
 	}
 
@@ -42,7 +42,7 @@ func (o *SaveOptions) Run() {
 	for _, header := range viper.GetStringSlice("headers") {
 		err := headers.Set(header)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error setting header: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -50,7 +50,7 @@ func (o *SaveOptions) Run() {
 	for _, param := range viper.GetStringSlice("parameters") {
 		err := params.Set(param)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error setting parameters: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 	}
@@ -85,7 +85,7 @@ func (o *SaveOptions) Run() {
 
 	id, err := s.InsertLoaderConfiguration(opts)
 	if err != nil {
-		fmt.Fprintf(o.Err, "Error on inserting loader opts: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,7 @@ var rootCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 	},
+
 	PreRun: func(cmd *cobra.Command, args []string) {
 		err := viper.BindPFlags(cmd.Flags())
 		if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,12 @@ var rootCmd = &cobra.Command{
 			log.Fatal(err)
 		}
 	},
+	PreRun: func(cmd *cobra.Command, args []string) {
+		err := viper.BindPFlags(cmd.Flags())
+		if err != nil {
+			log.Fatalf("Can't bind flags: %v", err)
+		}
+	},
 }
 
 func writeProfile() error {

--- a/cmd/tags/add.go
+++ b/cmd/tags/add.go
@@ -1,12 +1,10 @@
 package tags
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 
-	"github.com/mattn/go-sqlite3"
 	"github.com/tmwalaszek/hload/cmd/cliio"
 	"github.com/tmwalaszek/hload/model"
 	"github.com/tmwalaszek/hload/storage"
@@ -54,14 +52,6 @@ func (o *AddOptions) Run() {
 
 	err = s.InsertLoaderConfigurationTags(o.UUID, loaderTags)
 	if err != nil {
-		var sqliteErr sqlite3.Error
-		if errors.As(err, &sqliteErr) {
-			if errors.Is(sqliteErr.Code, sqlite3.ErrConstraint) {
-				fmt.Fprintf(o.Err, "Error: could not insert loader configuration tags: %s", sqliteErr.Error())
-				os.Exit(1)
-			}
-		}
-
 		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}

--- a/cmd/tags/add.go
+++ b/cmd/tags/add.go
@@ -57,7 +57,7 @@ func (o *AddOptions) Run() {
 		var sqliteErr sqlite3.Error
 		if errors.As(err, &sqliteErr) {
 			if errors.Is(sqliteErr.Code, sqlite3.ErrConstraint) {
-				fmt.Fprintf(o.Err, "Error: loader configuration already contains provided tags")
+				fmt.Fprintf(o.Err, "Error: could not insert loader configuration tags: %s", sqliteErr.Error())
 				os.Exit(1)
 			}
 		}

--- a/cmd/tags/add.go
+++ b/cmd/tags/add.go
@@ -30,13 +30,24 @@ func (o *AddOptions) Run() {
 
 	loaderTags := make([]*model.LoaderTag, 0)
 	for _, tag := range o.TagNames {
-		tags := strings.Split(tag, ":")
-		if len(tags) == 2 {
-			loaderTags = append(loaderTags, &model.LoaderTag{
-				Key:   tags[0],
-				Value: tags[1],
-			})
+		tags := strings.SplitN(tag, "=", 2)
+		var key, value string
+		if len(tags) == 1 {
+			if tags[0] == "" {
+				fmt.Fprintf(o.Err, "Empty tag name: %s", tag)
+				os.Exit(1)
+			}
+
+			key = tags[0]
+		} else {
+			key = tags[0]
+			value = tags[1]
 		}
+
+		loaderTags = append(loaderTags, &model.LoaderTag{
+			Key:   key,
+			Value: value,
+		})
 	}
 
 	err = s.InsertLoaderConfigurationTags(o.UUID, loaderTags)
@@ -60,6 +71,13 @@ func NewTagsAddCmd(cliIO cliio.IO) *cobra.Command {
 			opts.Run()
 		},
 	}
+
+	//cmd.PreRun = func(cmd *cobra.Command, args []string) {
+	//	err := viper.BindPFlags(cmd.Flags())
+	//	if err != nil {
+	//		log.Fatalf("Can't bind flags: %v", err)
+	//	}
+	//}
 
 	cmd.Flags().StringVarP(&opts.UUID, "uuid", "u", "", "Loader configuration UUID")
 	cmd.Flags().StringArrayVarP(&opts.TagNames, "tag", "t", []string{}, "Tag names pairs")

--- a/cmd/tags/add.go
+++ b/cmd/tags/add.go
@@ -72,13 +72,6 @@ func NewTagsAddCmd(cliIO cliio.IO) *cobra.Command {
 		},
 	}
 
-	//cmd.PreRun = func(cmd *cobra.Command, args []string) {
-	//	err := viper.BindPFlags(cmd.Flags())
-	//	if err != nil {
-	//		log.Fatalf("Can't bind flags: %v", err)
-	//	}
-	//}
-
 	cmd.Flags().StringVarP(&opts.UUID, "uuid", "u", "", "Loader configuration UUID")
 	cmd.Flags().StringArrayVarP(&opts.TagNames, "tag", "t", []string{}, "Tag names pairs")
 

--- a/cmd/tags/delete.go
+++ b/cmd/tags/delete.go
@@ -49,7 +49,7 @@ func (o *DeleteOptions) Run() {
 }
 
 func NewTagsDelCmd(cliIO cliio.IO) *cobra.Command {
-	opts := AddOptions{
+	opts := DeleteOptions{
 		IO: cliIO,
 	}
 

--- a/cmd/tags/delete.go
+++ b/cmd/tags/delete.go
@@ -24,7 +24,7 @@ type DeleteOptions struct {
 func (o *DeleteOptions) Run() {
 	s, err := storage.NewStorage(viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't create storage handler: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
@@ -41,7 +41,7 @@ func (o *DeleteOptions) Run() {
 
 	err = s.DeleteLoaderTag(o.UUID, loaderTags)
 	if err != nil {
-		fmt.Fprintf(o.Err, "Error while inserting tags: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/tags/find.go
+++ b/cmd/tags/find.go
@@ -28,12 +28,16 @@ type FindOptions struct {
 func (o *FindOptions) Complete() {
 	for _, tag := range viper.GetStringSlice("tag") {
 		tags := strings.SplitN(tag, "=", 2)
+		var key, value string
 		if len(tags) == 2 {
-			o.Tags = append(o.Tags, &model.LoaderTag{
-				Key:   tags[0],
-				Value: tags[1],
-			})
+			value = tags[1]
 		}
+
+		key = tags[0]
+		o.Tags = append(o.Tags, &model.LoaderTag{
+			Key:   key,
+			Value: value,
+		})
 	}
 
 	r, err := templates.NewRenderTemplate(viper.GetString("template"), viper.GetString("db"))
@@ -151,7 +155,6 @@ func NewTagsFindCmd(cliIO cliio.IO) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.UUID, "uuid", "u", "", "Loader configuration UUID from database")
 	cmd.Flags().StringVarP(&opts.Name, "name", "n", "", "Tag name")
-	// Tag pair key:value
 	cmd.Flags().StringArrayP("tag", "t", []string{}, "Tag names pairs - key=value")
 
 	return cmd

--- a/cmd/tags/find.go
+++ b/cmd/tags/find.go
@@ -38,7 +38,7 @@ func (o *FindOptions) Complete() {
 
 	r, err := templates.NewRenderTemplate(viper.GetString("template"), viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't create render template: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
@@ -48,21 +48,21 @@ func (o *FindOptions) Complete() {
 func (o *FindOptions) Run() {
 	s, err := storage.NewStorage(viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't create storage handler: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
 	if o.UUID != "" {
 		loaderTags, err := s.GetLoaderTags(o.UUID)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while getting tags: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
 		if len(loaderTags) > 0 {
 			output, err := o.render.RenderTags(o.UUID, loaderTags)
 			if err != nil {
-				fmt.Fprintf(o.Err, "Error while rendering tags: %v", err)
+				fmt.Fprintf(o.Err, "Error: %v", err)
 				os.Exit(1)
 			}
 
@@ -74,24 +74,28 @@ func (o *FindOptions) Run() {
 	if o.Name != "" {
 		tags, err := s.GetLoaderTagsByKey(o.Name)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while gettings tags: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
 		output, err := o.render.RenderTagsMap(tags)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while rendering tags: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
-		fmt.Fprintf(o.Out, "%s\n", output)
+		if len(output) > 0 {
+			fmt.Fprintf(o.Out, "%s\n", output)
+			os.Exit(0)
+		}
+
 		os.Exit(0)
 	}
 
 	if len(o.Tags) > 0 {
 		loaderConfs, err := s.GetLoaderByTags(o.Tags)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while gettting loaders configuration: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
@@ -112,12 +116,16 @@ func (o *FindOptions) Run() {
 
 		b, err := o.render.RenderOutput(loaderConfiguration)
 		if err != nil {
-			fmt.Fprintf(o.Err, "Error while rendering template: %v", err)
+			fmt.Fprintf(o.Err, "Error: %v", err)
 			os.Exit(1)
 		}
 
-		fmt.Fprintf(o.Out, "%s\n", string(b))
-		os.Exit(0)
+		if len(b) > 0 {
+			fmt.Fprintf(o.Out, "%s\n", string(b))
+			os.Exit(0)
+		}
+
+		os.Exit(1)
 	}
 }
 

--- a/cmd/tags/find.go
+++ b/cmd/tags/find.go
@@ -59,14 +59,16 @@ func (o *FindOptions) Run() {
 			os.Exit(1)
 		}
 
-		output, err := o.render.RenderTags(o.UUID, loaderTags)
-		if err != nil {
-			fmt.Fprintf(o.Err, "Error while rendering tags: %v", err)
-			os.Exit(1)
-		}
+		if len(loaderTags) > 0 {
+			output, err := o.render.RenderTags(o.UUID, loaderTags)
+			if err != nil {
+				fmt.Fprintf(o.Err, "Error while rendering tags: %v", err)
+				os.Exit(1)
+			}
 
-		fmt.Fprintf(o.Out, "%s\n", string(output))
-		os.Exit(0)
+			fmt.Fprintf(o.Out, "%s\n", string(output))
+			os.Exit(0)
+		}
 	}
 
 	if o.Name != "" {

--- a/cmd/tags/tags.go
+++ b/cmd/tags/tags.go
@@ -1,6 +1,9 @@
 package tags
 
 import (
+	"log"
+
+	"github.com/spf13/viper"
 	"github.com/tmwalaszek/hload/cmd/cliio"
 
 	"github.com/spf13/cobra"
@@ -12,6 +15,12 @@ func NewTagsCmd(cliIO cliio.IO) *cobra.Command {
 		Short: "Manage tags",
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Usage()
+		},
+		PreRun: func(cmd *cobra.Command, args []string) {
+			err := viper.BindPFlags(cmd.Flags())
+			if err != nil {
+				log.Fatalf("Can't bind flags: %v", err)
+			}
 		},
 	}
 

--- a/cmd/tags/tags.go
+++ b/cmd/tags/tags.go
@@ -18,5 +18,6 @@ func NewTagsCmd(cliIO cliio.IO) *cobra.Command {
 	cmd.AddCommand(NewTagsFindCmd(cliIO))
 	cmd.AddCommand(NewTagsAddCmd(cliIO))
 	cmd.AddCommand(NewTagsDelCmd(cliIO))
+	cmd.AddCommand(NewTagsUpdateCommand(cliIO))
 	return cmd
 }

--- a/cmd/tags/update.go
+++ b/cmd/tags/update.go
@@ -23,7 +23,7 @@ type UpdateOptions struct {
 func (o *UpdateOptions) Complete() {
 	s, err := storage.NewStorage(viper.GetString("db"))
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't create storage handler: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 
@@ -33,7 +33,7 @@ func (o *UpdateOptions) Complete() {
 func (o *UpdateOptions) Run() {
 	err := o.s.UpdateLoaderTag(o.UUID, o.Key, o.Value)
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't update tag: %v", err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/tags/update.go
+++ b/cmd/tags/update.go
@@ -1,0 +1,67 @@
+package tags
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/tmwalaszek/hload/cmd/cliio"
+	"github.com/tmwalaszek/hload/storage"
+)
+
+type UpdateOptions struct {
+	cliio.IO
+
+	s *storage.Storage
+
+	UUID  string
+	Key   string
+	Value string
+}
+
+func (o *UpdateOptions) Complete() {
+	s, err := storage.NewStorage(viper.GetString("db"))
+	if err != nil {
+		fmt.Fprintf(o.Err, "Can't create storage handler: %v", err)
+		os.Exit(1)
+	}
+
+	o.s = s
+}
+
+func (o *UpdateOptions) Run() {
+	err := o.s.UpdateLoaderTag(o.UUID, o.Key, o.Value)
+	if err != nil {
+		fmt.Fprintf(o.Err, "Can't update tag: %v", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(o.Err, "Tag %s has been updated", o.Key)
+	os.Exit(0)
+}
+
+func NewTagsUpdateCommand(cliIO cliio.IO) *cobra.Command {
+	opts := UpdateOptions{
+		IO: cliIO,
+	}
+
+	cmd := &cobra.Command{
+		Use:   "update",
+		Short: "Update a tag",
+		Run: func(cmd *cobra.Command, args []string) {
+			opts.Complete()
+			opts.Run()
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.UUID, "uuid", "u", "", "tag UUID")
+	cmd.Flags().StringVarP(&opts.Key, "key", "k", "", "tag key name")
+	cmd.Flags().StringVarP(&opts.Value, "value", "v", "", "tag value")
+
+	_ = cmd.MarkFlagRequired("uuid")
+	_ = cmd.MarkFlagRequired("key")
+	_ = cmd.MarkFlagRequired("value")
+
+	return cmd
+}

--- a/cmd/template/add.go
+++ b/cmd/template/add.go
@@ -3,7 +3,6 @@ package template
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -72,13 +71,6 @@ func NewTemplateAddCmd(cliIO cliio.IO) *cobra.Command {
 			opts.Complete()
 			opts.Run()
 		},
-	}
-
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.Fatalf("Can't bind flags: %v", err)
-		}
 	}
 
 	cmd.Flags().StringVarP(&opts.TemplateName, "name", "n", "", "Template name")

--- a/cmd/template/delete.go
+++ b/cmd/template/delete.go
@@ -2,7 +2,6 @@ package template
 
 import (
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -51,13 +50,6 @@ func NewTemplateDeleteCmd(cliIO cliio.IO) *cobra.Command {
 			opts.Complete()
 			opts.Run()
 		},
-	}
-
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.Fatalf("Can't bind flags: %v", err)
-		}
 	}
 
 	cmd.Flags().StringVarP(&opts.TemplateName, "name", "n", "", "Template name")

--- a/cmd/template/delete.go
+++ b/cmd/template/delete.go
@@ -30,7 +30,7 @@ func (o *DeleteOptions) Complete() {
 func (o *DeleteOptions) Run() {
 	err := o.storage.DeleteTemplate(o.TemplateName)
 	if err != nil {
-		fmt.Fprintf(o.Err, "Can't delete template %s: %v", o.TemplateName, err)
+		fmt.Fprintf(o.Err, "Error: %v", err)
 		os.Exit(1)
 	}
 

--- a/cmd/template/update.go
+++ b/cmd/template/update.go
@@ -3,7 +3,6 @@ package template
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -73,13 +72,6 @@ func NewTemplateUpdateCmd(cliIO cliio.IO) *cobra.Command {
 			opts.Complete()
 			opts.Run()
 		},
-	}
-
-	cmd.PreRun = func(cmd *cobra.Command, args []string) {
-		err := viper.BindPFlags(cmd.Flags())
-		if err != nil {
-			log.Fatalf("Can't bind flags: %v", err)
-		}
 	}
 
 	cmd.Flags().StringVarP(&opts.TemplateName, "name", "n", "", "Template name")

--- a/model/loader.go
+++ b/model/loader.go
@@ -109,6 +109,8 @@ func (p *Parameters) Set(value string) error {
 }
 
 type LoaderTag struct {
-	Key   string `db:"key" json:"key,omitempty"`
-	Value string `db:"value" json:"value,omitempty"`
+	Key        string    `db:"key" json:"key,omitempty"`
+	Value      string    `db:"value" json:"value,omitempty"`
+	CreateDate time.Time `db:"create_date" json:"create_date"`
+	UpdateDate time.Time `db:"update_date" json:"update_date"`
 }

--- a/storage/loader.go
+++ b/storage/loader.go
@@ -514,16 +514,7 @@ func (s *Storage) GetLoaderByTags(tags []*model.LoaderTag) ([]*model.Loader, err
 		return nil, err
 	}
 
-	args := make([]any, len(tags)*2)
-	i := 0
-	for _, tag := range tags {
-		args[i] = tag.Key
-		i++
-		args[i] = tag.Value
-		i++
-	}
-
-	err = s.db.Select(&loaderConfAgg, sqlQuery, args...)
+	err = s.db.Select(&loaderConfAgg, sqlQuery)
 	if err != nil {
 		return nil, fmt.Errorf("db error: %w", err)
 	}

--- a/storage/loader.go
+++ b/storage/loader.go
@@ -398,7 +398,7 @@ func (s *Storage) GetLoaderByID(loaderUUID string) (*model.Loader, error) {
 	}
 
 	if len(confs) == 0 {
-		return nil, fmt.Errorf("loader with id %s not found", loaderUUID)
+		return nil, fmt.Errorf("loader configuration %s not found", loaderUUID)
 	}
 
 	return confs[0], nil

--- a/storage/migrations/000003_tags-table.up.sql
+++ b/storage/migrations/000003_tags-table.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE loader_tag ADD COLUMN create_date DATE DEFAULT (datetime('now'));
+ALTER TABLE loader_tag ADD COLUMN update_date DATE DEFAULT (datetime('now'))

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/jedib0t/go-pretty/v6/text"
@@ -68,6 +69,13 @@ func generateSQLFromTemplate(tmplFile, tmpl string, data any) (string, error) {
 		},
 		"bold": func(x string) string {
 			return text.Bold.Sprint(x)
+		},
+		"join": func(x []string) string {
+			for i, s := range x {
+				x[i] = fmt.Sprintf("'%s'", s)
+			}
+
+			return strings.Join(x, ",")
 		},
 	}
 

--- a/storage/sql.go
+++ b/storage/sql.go
@@ -54,6 +54,8 @@ var (
 	deleteTemplate string
 	//go:embed sql/update_template.sql
 	updateTemplate string
+	//go:embed sql/update_loader_tag.sql
+	updateLoaderTag string
 )
 
 // data is optional depending on the template

--- a/storage/sql/select_loader.tmpl
+++ b/storage/sql/select_loader.tmpl
@@ -1,8 +1,8 @@
 {{ define "main" }}
 SELECT loader.*,
        loader_requests_details.*,
-       coalesce(group_concat(DISTINCT loader_tag.key), '') AS tags_keys_agg,
-       coalesce(group_concat(DISTINCT loader_tag.value), '') AS tags_values_agg,
+       coalesce(group_concat(loader_tag.key), '') AS tags_keys_agg,
+       coalesce(group_concat(loader_tag.value), '') AS tags_values_agg,
        coalesce(group_concat(DISTINCT header.header), '') AS headers_agg,
        coalesce(group_concat(DISTINCT parameter.parameters), '') AS parameters_agg
 FROM loader
@@ -49,7 +49,7 @@ LIMIT $3;
 {{ template "main" }}
 {{ $lengthTags := len .Tags }}
 {{ $i := 0 }}
-{{ printf "WHERE " -}}
+{{ printf "WHERE loader.uuid IN (SELECT loader.uuid from loader, loader_tag WHERE " -}}
 {{ range .Tags -}}
     {{ $place_holder_one := add $i 1 }}
     {{ $place_holder_two := add $i 2 }}
@@ -59,5 +59,6 @@ LIMIT $3;
     {{ printf " AND " -}}
     {{ end }}
 {{ end }}
+AND loader.uuid = loader_tag.loader_uuid)
 GROUP BY loader.uuid
 {{ end }}

--- a/storage/sql/select_loader.tmpl
+++ b/storage/sql/select_loader.tmpl
@@ -47,18 +47,13 @@ LIMIT $3;
 
 {{ define "by_loader.tag" }}
 {{ template "main" }}
-{{ $lengthTags := len .Tags }}
-{{ $i := 0 }}
-{{ printf "WHERE loader.uuid IN (SELECT loader.uuid from loader, loader_tag WHERE " -}}
-{{ range .Tags -}}
-    {{ $place_holder_one := add $i 1 }}
-    {{ $place_holder_two := add $i 2 }}
-    {{ printf "loader_tag.key=$%d AND loader_tag.value=$%d" $place_holder_one $place_holder_two -}}
-    {{ $i = add $i 2 }}
-    {{ if lt $i $lengthTags }}
-    {{ printf " AND " -}}
-    {{ end }}
+{{ $keys := join .Keys -}}
+{{ $values := join .Values -}}
+{{ $in_keys := printf "loader_tag.key IN (%s)" $keys -}}
+{{ $in_values := "" -}}
+{{ if gt (len $values) 0 }}
+{{ $in_values = printf "AND loader_tag.value IN (%s)" $values -}}
 {{ end }}
-AND loader.uuid = loader_tag.loader_uuid)
+{{ printf "WHERE loader.uuid IN (SELECT loader.uuid from loader, loader_tag WHERE %s %s AND loader.uuid = loader_tag.loader_uuid)" $in_keys $in_values}}
 GROUP BY loader.uuid
 {{ end }}

--- a/storage/sql/select_loader_tags.sql
+++ b/storage/sql/select_loader_tags.sql
@@ -1,1 +1,1 @@
-SELECT key,value FROM loader_tag WHERE loader_uuid=$1
+SELECT key,value,create_date,update_date FROM loader_tag WHERE loader_uuid=$1

--- a/storage/sql/select_loader_tags_by_name.sql
+++ b/storage/sql/select_loader_tags_by_name.sql
@@ -1,1 +1,1 @@
-SELECT key,value,loader_uuid FROM loader_tag WHERE key=$1
+SELECT key,value,loader_uuid,create_date,update_date FROM loader_tag WHERE key=$1

--- a/storage/sql/update_loader_tag.sql
+++ b/storage/sql/update_loader_tag.sql
@@ -1,0 +1,1 @@
+UPDATE loader_tag SET value = $1, update_date = datetime('now') WHERE key = $2 AND loader_uuid = $3;

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -192,7 +192,7 @@ func mapLoader(loaderAgg []*loaderAggregated) ([]*model.Loader, error) {
 			confAgg.Loader.Parameters = parameter
 		}
 
-		if confAgg.TagsKeys != "" && confAgg.TagsValues != "" {
+		if confAgg.TagsKeys != "" {
 			tagsKeys := strings.Split(confAgg.TagsKeys, ",")
 			tagsValues := strings.Split(confAgg.TagsValues, ",")
 			if len(tagsKeys) != len(tagsValues) {

--- a/templates/default/list_template.tmpl
+++ b/templates/default/list_template.tmpl
@@ -110,7 +110,7 @@ Tags:
 {{ if gt $lenght 0 -}}
     {{ printf "  Tags:\n" }}
 {{- range $key, $value := $element.Loader.Tags -}}
-{{ if eq $value.Value " " -}}
+{{ if ne $value.Value "" -}}
     {{ printf "    %d: %s=%s\n" $key $value.Key $value.Value -}}
 {{ else -}}
    {{ printf "    %d: %s\n" $key $value.Key -}}

--- a/templates/default/list_template.tmpl
+++ b/templates/default/list_template.tmpl
@@ -110,7 +110,11 @@ Tags:
 {{ if gt $lenght 0 -}}
     {{ printf "  Tags:\n" }}
 {{- range $key, $value := $element.Loader.Tags -}}
+{{ if eq $value.Value " " -}}
     {{ printf "    %d: %s=%s\n" $key $value.Key $value.Value -}}
+{{ else -}}
+   {{ printf "    %d: %s\n" $key $value.Key -}}
+{{ end -}}
 {{ end -}}
 {{ end -}}
 {{ end -}}

--- a/templates/default/list_template.tmpl
+++ b/templates/default/list_template.tmpl
@@ -5,14 +5,15 @@ Tags:
     {{ if gt $index 0 -}}
     {{ printf "\n" -}}
     {{ end -}}
-    {{ printf "  %s: %s" $tag.Key $tag.Value -}}
+    {{ printf "  %s: %s (CreatedAt %s UpdatedAt: %s )" $tag.Key $tag.Value (timeInLoc $tag.CreateDate) (timeInLoc $tag.UpdateDate) -}}
 {{ end -}}
 {{ end -}}
 
 {{ define "tags_map" -}}
 {{ range $key, $value := . -}}
-Loader UUID: {{ $key }}
-  {{ $value.Key }}: {{ $value.Value -}}
+{{ printf "Loader UUID: %s" $key -}}
+  {{ printf "\n  - %s: %s (CreatedAt: %s UpdatedAt: %s)" $value.Key $value.Value (timeInLoc $value.CreateDate) (timeInLoc $value.UpdateDate) -}}
+  {{ printf "\n" -}}
 {{ end -}}
 {{ end -}}
 
@@ -22,9 +23,9 @@ Loader UUID: {{ $key }}
   Loader UUID: {{ $element.Loader.UUID }}
   Target Host: {{ $element.Loader.URL }}
   Created at: {{ timeInLoc $element.Loader.CreateDate }}
-  Name: {{ $element.Loader.Name }}
+  Name: {{ $element.Loader.Name -}}
 {{ if not $.Short -}}
-{{ printf "  HTTP Engine: %s\n" $element.Loader.HTTPEngine -}}
+{{ printf "\n  HTTP Engine: %s\n" $element.Loader.HTTPEngine -}}
 {{ printf "  Description: %s\n" $element.Loader.Description -}}
 {{ printf "  Concurrent connection: %d\n" $element.Loader.Connections -}}
 
@@ -118,7 +119,6 @@ Loader UUID: {{ $key }}
 {{ end -}}
 
 {{ define "summaries" -}}
-{{ bold "Summaries:" }}
 {{ range $index, $loader := .Loaders -}}
 {{ range $index, $element := $loader.Summaries -}}
 {{ printf "---\n" -}}


### PR DESCRIPTION
- The `loader find` subcommand now supports find by tags. 
Example
```
./hload loader find --tag key3
* Loader 0:
  Loader UUID: 01f23c3c-11d9-4cdc-b576-1022a892aed0
  Target Host: http://127.0.0.1:8000
  Created at: 2024-05-20 23:24:05 +0200 CEST
  Name: Configuration Mon, 20 May 2024 23:24:05.195
  HTTP Engine: fast_http
  Description: Default loader description
  Concurrent connection: 10
  Request count: 10
  Tags:
    0: key3=value3
    1: key4=value4
```
- The format of the tag is `key=value`
- We can search using only key (omit the =value)
- Change some error messages with not needed comments
- Minor fixes.